### PR TITLE
[week1] 1주차 과제 - 로그인 로직 수정 및 UIPickerView 이용한 기능 추가

### DIFF
--- a/ParkYunBin-practice/Base.lproj/Main.storyboard
+++ b/ParkYunBin-practice/Base.lproj/Main.storyboard
@@ -39,8 +39,11 @@
                                 </connections>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B1s-lk-Fzp">
-                                <rect key="frame" x="162" y="387" width="69" height="35"/>
-                                <state key="normal" title="Button"/>
+                                <rect key="frame" x="162.33333333333334" y="387" width="68.333333333333343" height="34.333333333333314"/>
+                                <color key="backgroundColor" red="0.94509804249999996" green="0.60784316059999999" blue="0.57647061349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="로그인"/>
                                 <buttonConfiguration key="configuration" style="plain" title="로그인"/>
                                 <connections>
                                     <action selector="didButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aDv-JW-13Y"/>
@@ -64,6 +67,9 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="m4z-3w-qOH"/>
+                    <connections>
+                        <outlet property="loginButton" destination="B1s-lk-Fzp" id="Mlx-mS-PJu"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/ParkYunBin-practice/Base.lproj/Main.storyboard
+++ b/ParkYunBin-practice/Base.lproj/Main.storyboard
@@ -83,45 +83,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q2N-nH-fa8">
-                                <rect key="frame" x="155" y="409" width="83" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="linkColor"/>
-                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="뒤로가기"/>
-                                <connections>
-                                    <action selector="backButtonTapped:" destination="nJE-2p-m13" eventType="touchUpInside" id="dYk-PJ-jgB"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IrW-js-mwa">
-                                <rect key="frame" x="30" y="179" width="333" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="박윤빈님 만나서 반가워요" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IrW-js-mwa">
+                                <rect key="frame" x="30" y="82" width="279" height="33.666666666666657"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SOPT를 알게되신 계기가 무엇인가요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tPB-d8-zWI">
+                                <rect key="frame" x="30" y="145.66666666666666" width="257" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tfj-Ua-W8X">
-                                <rect key="frame" x="30" y="230" width="333" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="4J3-3e-xTl">
+                                <rect key="frame" x="30" y="211.66666666666666" width="333" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Ep6-bM-LTt"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="tfj-Ua-W8X" firstAttribute="top" secondItem="IrW-js-mwa" secondAttribute="bottom" constant="30" id="6pU-pf-94p"/>
-                            <constraint firstItem="Ep6-bM-LTt" firstAttribute="trailing" secondItem="IrW-js-mwa" secondAttribute="trailing" constant="30" id="8HH-mf-P1d"/>
-                            <constraint firstItem="IrW-js-mwa" firstAttribute="top" secondItem="Ep6-bM-LTt" secondAttribute="top" constant="120" id="SvI-tx-0ju"/>
-                            <constraint firstItem="Ep6-bM-LTt" firstAttribute="trailing" secondItem="tfj-Ua-W8X" secondAttribute="trailing" constant="30" id="aNb-fi-ihK"/>
+                            <constraint firstItem="4J3-3e-xTl" firstAttribute="top" secondItem="tPB-d8-zWI" secondAttribute="bottom" constant="45" id="ASc-bd-0f2"/>
+                            <constraint firstItem="tPB-d8-zWI" firstAttribute="leading" secondItem="Ep6-bM-LTt" secondAttribute="leading" constant="30" id="ExB-iq-iuF"/>
+                            <constraint firstItem="Ep6-bM-LTt" firstAttribute="trailing" secondItem="4J3-3e-xTl" secondAttribute="trailing" constant="30" id="YYR-AS-l4j"/>
+                            <constraint firstItem="IrW-js-mwa" firstAttribute="top" secondItem="Ep6-bM-LTt" secondAttribute="top" constant="23" id="dRv-73-bqv"/>
                             <constraint firstItem="IrW-js-mwa" firstAttribute="leading" secondItem="Ep6-bM-LTt" secondAttribute="leading" constant="30" id="lRm-5k-U0C"/>
-                            <constraint firstItem="tfj-Ua-W8X" firstAttribute="leading" secondItem="Ep6-bM-LTt" secondAttribute="leading" constant="30" id="vB7-cL-98y"/>
+                            <constraint firstItem="tPB-d8-zWI" firstAttribute="top" secondItem="IrW-js-mwa" secondAttribute="bottom" constant="30" id="x3q-Uo-rnC"/>
+                            <constraint firstItem="4J3-3e-xTl" firstAttribute="leading" secondItem="Ep6-bM-LTt" secondAttribute="leading" constant="30" id="zMy-8s-Xst"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="w38-hQ-BCa"/>
                     <connections>
                         <outlet property="emailLabel" destination="IrW-js-mwa" id="Wdb-hh-y7W"/>
-                        <outlet property="passwordLabel" destination="tfj-Ua-W8X" id="MGS-Q0-qBq"/>
+                        <outlet property="showPickerTextField" destination="4J3-3e-xTl" id="bL6-pP-UyL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BAr-MZ-9bp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -148,9 +143,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/ParkYunBin-practice/ResultViewController.swift
+++ b/ParkYunBin-practice/ResultViewController.swift
@@ -10,33 +10,76 @@ import UIKit
 class ResultViewController: UIViewController {
     
     private var email: String = ""
-    private var password: String = ""
-    
+    private let reason: [String] = ["지인을 통해", "인스타그램", "공식 홈페이지", "페이스북", "유튜브 홍보 영상"]
+    private let pickerView = UIPickerView()
     @IBOutlet var emailLabel: UILabel!
-    @IBOutlet var passwordLabel: UILabel!
+    @IBOutlet weak var showPickerTextField: UITextField!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        bindText()
-
+        setUI()
         // Do any additional setup after loading the view.
     }
     
-    @IBAction func backButtonTapped(_ sender: Any) {
-        if self.navigationController != nil {
-            self.navigationController?.popViewController(animated: true)
-        } else {
-            self.dismiss(animated: true)
-        }
+    // MARK: - Functions
+    
+    private func setUI() {
+        bindText()
+        setPickerView()
+        setToolBar()
+        showPickerTextField.tintColor = .clear
     }
     
-    func bindText() {
+    private func bindText() {
         self.emailLabel.text = "\(email)"
-        self.passwordLabel.text = "\(password)"
     }
     
-    func bindText(email: String, password: String) {
-        self.email = "email : \(email)"
-        self.password = "password : \(password)"
+    // overload
+    func bindText(email: String) {
+        self.email = "\(email) 님\n만나서 반가워요!"
     }
+    
+    private func setPickerView() {
+        pickerView.delegate = self
+        showPickerTextField.inputView = pickerView
+    }
+    
+    private func setToolBar() {
+        let toolBar = UIToolbar()
+        toolBar.sizeToFit()
+        let button = UIBarButtonItem(title: "선택",
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(self.action)
+        )
+        toolBar.setItems([button], animated: true)
+        toolBar.isUserInteractionEnabled = true
+        showPickerTextField.inputAccessoryView = toolBar
+    }
+    
+    @objc
+    private func action() {
+        self.showPickerTextField.resignFirstResponder()
+    }
+}
+
+// MARK: - UIPickerViewDelegate
+
+extension ResultViewController: UIPickerViewDelegate, UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return reason.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return reason[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        showPickerTextField.text = reason[row]
+    }
+    
 }

--- a/ParkYunBin-practice/ResultViewController.swift
+++ b/ParkYunBin-practice/ResultViewController.swift
@@ -17,6 +17,7 @@ class ResultViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        bindText()
 
         // Do any additional setup after loading the view.
     }
@@ -29,8 +30,13 @@ class ResultViewController: UIViewController {
         }
     }
     
+    func bindText() {
+        self.emailLabel.text = "\(email)"
+        self.passwordLabel.text = "\(password)"
+    }
+    
     func bindText(email: String, password: String) {
-        self.emailLabel.text = "email : \(email)"
-        self.passwordLabel.text = "password : \(password)"
+        self.email = "email : \(email)"
+        self.password = "password : \(password)"
     }
 }

--- a/ParkYunBin-practice/UIView+.swift
+++ b/ParkYunBin-practice/UIView+.swift
@@ -1,0 +1,36 @@
+//
+//  UIView+.swift
+//  ParkYunBin-practice
+//
+//  Created by 박윤빈 on 2023/10/13.
+//
+
+import UIKit
+
+extension UIView {
+    func showToast(message: String) {
+        let toastLabel = UILabel()
+        toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        toastLabel.textColor = UIColor.white
+        toastLabel.textAlignment = .center
+        toastLabel.font = UIFont(name: "Montserrat-Light", size: 12.0)
+        toastLabel.text = message
+        toastLabel.alpha = 1.0
+        toastLabel.layer.cornerRadius = 10
+        toastLabel.clipsToBounds = true
+        
+        let toastWidth = toastLabel.intrinsicContentSize.width + 20
+        let toastHeight = toastLabel.intrinsicContentSize.height + 10
+        toastLabel.frame = CGRect(x: self.frame.size.width/2 - toastWidth/2,
+                                   y: self.frame.size.height - toastHeight - 30,
+                                   width: toastWidth,
+                                   height: toastHeight)
+        self.addSubview(toastLabel)
+        
+        UIView.animate(withDuration: 2.0, delay: 0.1, options: .curveEaseOut, animations: {
+            toastLabel.alpha = 0.0
+        }, completion: {(isCompleted) in
+            toastLabel.removeFromSuperview()
+        })
+    }
+}

--- a/ParkYunBin-practice/ViewController.swift
+++ b/ParkYunBin-practice/ViewController.swift
@@ -35,9 +35,11 @@ class ViewController: UIViewController {
     }
     
     func pushToResultVC() {
-        guard let resultVC = self.storyboard?.instantiateViewController(identifier: "ResultViewController") as? ResultViewController else {return}
+        
+        guard let resultVC = self.storyboard?.instantiateViewController(withIdentifier: "ResultViewController") as? ResultViewController else {return}
         resultVC.bindText(email: idText, password: passwordText)
-        self.navigationController?.pushViewController(resultVC, animated: true)
+            self.navigationController?.pushViewController(resultVC, animated: true)
+        
     }
         
     func presentToResultVC() {

--- a/ParkYunBin-practice/ViewController.swift
+++ b/ParkYunBin-practice/ViewController.swift
@@ -10,10 +10,12 @@ import UIKit
 class ViewController: UIViewController {
     private var idText: String = ""
     private var passwordText: String = ""
+    @IBOutlet var loginButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        
     }
     @IBAction func didButtonTapped(_ sender: Any) {
         print("\(idText)\n\(passwordText)")
@@ -34,12 +36,23 @@ class ViewController: UIViewController {
         }
     }
     
+    func checkInputState(idInput: String, passwordInput: String) -> Bool {
+        if idInput != "" && passwordInput != "" {
+            return true
+        } else {
+            view.showToast(message: "아이디 및 비밀번호를 모두 입력해주세요!")
+            return false
+        }
+    }
+    
     func pushToResultVC() {
-        
-        guard let resultVC = self.storyboard?.instantiateViewController(withIdentifier: "ResultViewController") as? ResultViewController else {return}
-        resultVC.bindText(email: idText, password: passwordText)
+        if checkInputState(idInput: idText, passwordInput: passwordText) {
+            
+            guard let resultVC = self.storyboard?.instantiateViewController(withIdentifier: "ResultViewController") as? ResultViewController else {return}
+            resultVC.bindText(email: idText, password: passwordText)
             self.navigationController?.pushViewController(resultVC, animated: true)
-        
+            
+        }
     }
         
     func presentToResultVC() {

--- a/ParkYunBin-practice/ViewController.swift
+++ b/ParkYunBin-practice/ViewController.swift
@@ -36,22 +36,13 @@ class ViewController: UIViewController {
         }
     }
     
-    func checkInputState(idInput: String, passwordInput: String) -> Bool {
-        if idInput != "" && passwordInput != "" {
-            return true
-        } else {
-            view.showToast(message: "아이디 및 비밀번호를 모두 입력해주세요!")
-            return false
-        }
-    }
-    
     func pushToResultVC() {
-        if checkInputState(idInput: idText, passwordInput: passwordText) {
-            
+        if idText != "" && passwordText != "" {
             guard let resultVC = self.storyboard?.instantiateViewController(withIdentifier: "ResultViewController") as? ResultViewController else {return}
             resultVC.bindText(email: idText)
             self.navigationController?.pushViewController(resultVC, animated: true)
-            
+        } else {
+            view.showToast(message: "아이디 및 비밀번호를 모두 입력해주세요!")
         }
     }
 }

--- a/ParkYunBin-practice/ViewController.swift
+++ b/ParkYunBin-practice/ViewController.swift
@@ -49,16 +49,10 @@ class ViewController: UIViewController {
         if checkInputState(idInput: idText, passwordInput: passwordText) {
             
             guard let resultVC = self.storyboard?.instantiateViewController(withIdentifier: "ResultViewController") as? ResultViewController else {return}
-            resultVC.bindText(email: idText, password: passwordText)
+            resultVC.bindText(email: idText)
             self.navigationController?.pushViewController(resultVC, animated: true)
             
         }
-    }
-        
-    func presentToResultVC() {
-        guard let resultVC = self.storyboard?.instantiateViewController(withIdentifier: "ResultViewController") as? ResultViewController else {return}
-        resultVC.bindText(email: idText, password: passwordText)
-        self.present(resultVC, animated: true)
     }
 }
 


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- SOPT 1주차 과제 작업 완료했습니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 로그인 화면(`ViewController`)에서, `idTextField`와 `passwordTextField`가 둘 다 작성되지 않은 상태면, toast메세지를 띄우고 넘어가지 않도록 작성하였습니다.
- 위의 부분에서 로직 더 간결하고 이쁘게! 바꿀 수 있는 방법이 있다면 알려주세요!!!!!!!!!!!(나 분기처리 바보임)
- `ResultViewController`에서는 `UIPickerView` 사용하여 SOPT를 알게 된 동기를 선택하는 화면 구현하였습니다.


## 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 리뷰 관련 작업 | ![Simulator Screen Recording - iPhone 14 Pro - 2023-10-13 at 18 01 40](https://github.com/DO-SOPT-iOS-Part/ParkYunBin-practice/assets/109334968/7250d516-ab05-49f4-bb17-7af6f0cf62a6) |

